### PR TITLE
Racing styles fixes + update TextField + fixed UI datasync issue

### DIFF
--- a/client/client.ts
+++ b/client/client.ts
@@ -68,7 +68,7 @@ RegisterNuiCB(RacingEvents.DeleteTrack, (raceId: string, cb) => {
 });
 
 onNet('qb-phone:client:UpdateLapraces', () => {
-  npwdExports.sendUIMessage(NUIEvents.UpdateData);
+  npwdExports.sendUIMessage({type: NUIEvents.UpdateData});
 });
 
 RegisterNuiCB(NUIEvents.GetDistanceToRace, (data: GetDistanceToRaceInput, cb) => {

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,8 @@
+declare module '*.png' {
+    const value: any;
+    export = value;
+}
+
+declare module 'layout/ui' {
+    export const TextField: any;
+}

--- a/npwd.config.ts
+++ b/npwd.config.ts
@@ -13,7 +13,7 @@ interface Settings {
 
 export const path = '/racing';
 
-export default (settings: Settings) => ({
+export const externalAppConfig = (settings: Settings) => ({
   id: 'RACING',
   path,
   nameLocale: localizedAppName[settings?.language ?? defaultLanguage],
@@ -23,3 +23,5 @@ export default (settings: Settings) => ({
   notificationIcon: NotificationIcon,
   app: App,
 });
+
+export default externalAppConfig;

--- a/server/server.ts
+++ b/server/server.ts
@@ -57,6 +57,9 @@ onNet(RacingEvents.DeleteTrack, async (raceId: string) => {
     [player.PlayerData.citizenid, raceId],
   );
 
+  // This broadcasts the event so all clients update the UI after deleting a track
+  emitNet('qb-phone:client:UpdateLapraces', -1);
+
   if (affectedRows > 0) {
     emit(QBRacingEvents.CancelRace, raceId);
     emitNet(RacingEvents.SendDeleteTrack, src, true);

--- a/src/app.theme.ts
+++ b/src/app.theme.ts
@@ -13,17 +13,17 @@ export const lightTheme: ThemeOptions = {
       main: APP_PRIMARY_COLOR,
       dark: orange[700],
       light: orange[300],
-      contrastText: LIGHT_APP_TEXT_COLOR,
+      contrastText: DARK_APP_TEXT_COLOR,
     },
     secondary: {
       main: '#d32f2f',
       light: '#eb4242',
       dark: '#941212',
-      contrastText: LIGHT_APP_TEXT_COLOR,
+      contrastText: DARK_APP_TEXT_COLOR,
     },
     success: {
       main: '#2196f3',
-      contrastText: LIGHT_APP_TEXT_COLOR,
+      contrastText: DARK_APP_TEXT_COLOR,
     },
   },
 };

--- a/src/views/SetupRace.tsx
+++ b/src/views/SetupRace.tsx
@@ -8,11 +8,11 @@ import {
   Divider,
   Paper,
   Stack,
-  TextField,
   Tooltip,
   Typography,
   useTheme
 } from '@mui/material';
+import { TextField } from 'layout/ui';
 import React, { FormEvent, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
@@ -136,7 +136,7 @@ const SetupRace = () => {
             label="Select number of laps"
             type="number"
             value={laps}
-            onChange={(event) => setLaps(event.target.value)}
+            onChange={(event: any) => setLaps(event.target.value)}
             helperText="If lap count is 0, it will create a sprint."
           />
 

--- a/src/views/SetupRace.tsx
+++ b/src/views/SetupRace.tsx
@@ -11,6 +11,7 @@ import {
   TextField,
   Tooltip,
   Typography,
+  useTheme
 } from '@mui/material';
 import React, { FormEvent, useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
@@ -18,13 +19,14 @@ import { useRecoilValue } from 'recoil';
 import { path } from '../../npwd.config';
 import { NUIEvents, RacingEvents } from '../../types/Events';
 import { CreateRaceInput, GetDistanceToRaceInput, Track } from '../../types/Racing';
-import { sortedTracksAtom, tracksAtom } from '../atoms/tracks';
+import { sortedTracksAtom } from '../atoms/tracks';
 import TrackCard from '../components/TrackCard';
 import fetchNui from '../utils/fetchNui';
 
 const SetupRace = () => {
   const tracks = useRecoilValue(sortedTracksAtom);
   const history = useHistory();
+  const theme = useTheme();
   const { trackId } = useParams<{ trackId: string }>();
   const initialTrack = tracks.find((track) => track.id === parseInt(trackId));
 
@@ -138,7 +140,16 @@ const SetupRace = () => {
             helperText="If lap count is 0, it will create a sprint."
           />
 
-          <Button size="large" fullWidth type="submit" disabled={isDisabled} variant="contained">
+          <Button 
+            size="large" 
+            fullWidth 
+            type="submit" 
+            disabled={isDisabled} 
+            variant="contained"
+            sx={{
+              color: `${theme.palette.primary.contrastText} !important`,
+            }}
+          >
             Setup the race
           </Button>
         </Stack>

--- a/src/views/SetupTrack.tsx
+++ b/src/views/SetupTrack.tsx
@@ -1,5 +1,6 @@
 import { ErrorRounded } from '@mui/icons-material';
-import { Alert, Button, Divider, Stack, TextField, Typography } from '@mui/material';
+import { Alert, Button, Divider, Stack, Typography } from '@mui/material';
+import { TextField } from 'layout/ui';
 import React, { FormEvent, useState } from 'react';
 import { NUIEvents, RacingEvents } from '../../types/Events';
 import fetchNui from '../utils/fetchNui';
@@ -44,7 +45,7 @@ const SetupTrack = () => {
           <TextField
             label="Track name"
             value={trackName}
-            onChange={(event) => setTrackName(event.target.value)}
+            onChange={(event: any) => setTrackName(event.target.value)}
           />
 
           <Button type="submit">Start creating track</Button>

--- a/src/views/Tracks.tsx
+++ b/src/views/Tracks.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Add } from '@mui/icons-material';
-import { Divider, Fab, Stack, Tooltip, Typography } from '@mui/material';
+import { Divider, Fab, Stack, Typography, useTheme } from '@mui/material';
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useRecoilRefresher_UNSTABLE, useRecoilValue } from 'recoil';
@@ -21,6 +21,7 @@ const Tracks = () => {
   const tracks = useRecoilValue(sortedTracksAtom);
   const refreshTracks = useRecoilRefresher_UNSTABLE(sortedTracksAtom);
   const [isAuthorized, setIsAuthorized] = useState(false);
+  const theme = useTheme();
 
   useEffect(() => {
     fetchNui<boolean[], string>(NUIEvents.GetIsAuthorizedToCreateRaces).then((res) => {
@@ -42,9 +43,15 @@ const Tracks = () => {
 
       <FabContainer>
         <Fab
-          color="success"
           onClick={() => history.push(path + '/setupTrack')}
           disabled={!isAuthorized}
+          sx={{
+            backgroundColor: `${theme.palette.primary.main} !important`,
+            color: `${theme.palette.primary.contrastText} !important`,
+            '&:hover': {
+              backgroundColor: `${theme.palette.primary.dark} !important`,
+            }
+          }}
         >
           <Add />
         </Fab>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "noImplicitAny": true,
     "strictNullChecks": true,
     "module": "esnext",
-    "target": "es5",
+    "target": "es6",
     "jsx": "react",
     "allowJs": true,
     "moduleResolution": "node",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ const { dependencies, name } = packageJson;
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 const ReactRefreshTypeScript = require('react-refresh-typescript');
 const isDevelopment = process.env.NODE_ENV === 'development';
+const isIngame = process.env.REACT_APP_IN_GAME === '1';
 
 /* TODO: Fix for real */
 /* Probably bad way of fixing this */
@@ -62,6 +63,11 @@ module.exports = {
       filename: 'remoteEntry.js',
       exposes: {
         './config': './npwd.config',
+      },
+      remotes: {
+        layout: isIngame
+          ? 'layout@https://cfx-nui-npwd/resources/html/remoteEntry.js'
+          : 'layout@http://localhost:3000/remoteEntry.js',
       },
       shared: {
         ...dependencies,


### PR DESCRIPTION
This PR addresses 3 different problems.

1. The UI does not update when any of the events are triggered from the qb-lapraces via `qb-phone:client:UpdateLapraces`
  - This was happening because the event listener that calls `sendUIMessage` was missing the fact that the event takes an object with field `type`.
```ts
onNet('qb-phone:client:UpdateLapraces', () => {
  npwdExports.sendUIMessage({type: NUIEvents.UpdateData});
});
```
   - After making this change the DataSync component gets triggered and refreshes the UI
   - Also emit the event from DeleteTrack so the UI syncs across all clients UI
2. The input fields on the racing app, were not preventing outside keypresses (ie: character would still walk around when WASD pressed and other keybinds were triggered.
  - This issue is fixed by using `import { TextField } from 'layout/ui';`. This imports the TextField component defined in the `npwd` packages, which correctly handles the key presses.
3. There are a handful of styling issues happening in the app. 
- _Note: We found that these styling issues are caused by the Tailwind styles imported in the phone/src/main.css. It is styling button tag directly and as a result overrides the MUI styles in many places. This solution is more of a short term / bandaid fix until a longer term solution is figured out with the use of Tailwind and MUI styles._
- BEFORE (Tracks page)
  - ![image](https://github.com/npwd-community/npwd_qb_racing/assets/18689469/337ac924-6edf-4293-bbc0-12e3f519d020)
  - ![image](https://github.com/npwd-community/npwd_qb_racing/assets/18689469/da9902ee-8dd4-4ae0-a248-7e569f271f1c)

- AFTER
  - ![image](https://github.com/npwd-community/npwd_qb_racing/assets/18689469/413f33cf-49a4-4892-b093-f222dda8e1b0)
  - ![image](https://github.com/npwd-community/npwd_qb_racing/assets/18689469/1e54905d-a29c-434d-8952-abf4cebbf036)

- BEFORE (setup races)
  - ![image](https://github.com/npwd-community/npwd_qb_racing/assets/18689469/0b69827b-c871-42ea-b170-510141fa84c5)
  - ![image](https://github.com/npwd-community/npwd_qb_racing/assets/18689469/05d4e8c6-c409-4890-b9df-9ec3cf0f3b46)

- AFTER
  - ![image](https://github.com/npwd-community/npwd_qb_racing/assets/18689469/0cf06ba6-f456-4b73-bb96-125015c6119b)
  - ![image](https://github.com/npwd-community/npwd_qb_racing/assets/18689469/7705691c-fcb2-4433-ace3-06a5e655544b)
